### PR TITLE
Use GitHub API to get org admins

### DIFF
--- a/permissions-report/Dockerfile
+++ b/permissions-report/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.3-slim
 
-RUN gem install graphql-client
+RUN gem install graphql-client httparty
 
 COPY permissions-report.rb /
 

--- a/permissions-report/permissions-report.rb
+++ b/permissions-report/permissions-report.rb
@@ -111,7 +111,7 @@ loop do
 
     ratelimit_info(result.data.rate_limit)
 
-    if collaborator_paging.has_next_page then
+    if collaborator_paging&.has_next_page then
       collaborator_cursor = collaborator_paging.end_cursor
       STDERR.puts "Next page of collaborators, from #{collaborator_cursor}"
     else

--- a/permissions-report/permissions-report.rb
+++ b/permissions-report/permissions-report.rb
@@ -2,11 +2,11 @@
 
 require "graphql/client"
 require "graphql/client/http"
-require 'httparty'
-require 'pp'
-require 'json'
+require "httparty"
+require "pp"
+require "json"
 
-$auth = "bearer #{ENV['GITHUB_API_TOKEN']}"
+$auth = "bearer #{ENV["GITHUB_API_TOKEN"]}"
 
 module GitHubGraphQL
   HTTP = GraphQL::Client::HTTP.new("https://api.github.com/graphql") do
@@ -64,12 +64,12 @@ GRAPHQL
 
 $table_data = []
 
-response = HTTParty.get('https://api.github.com/orgs/jenkinsci/members?role=admin', :headers => {
-  'Authorization' => $auth,
+response = HTTParty.get("https://api.github.com/orgs/jenkinsci/members?role=admin", :headers => {
+  "Authorization" => $auth,
   "User-Agent" => "JenkinsCI report"
 })
 
-$org_admins = response.parsed_response.map{|user| user['login']&.downcase}
+$org_admins = response.parsed_response.map{|user| user["login"]&.downcase}
 
 def record_collaborator(repo_name, collaborator, permission)
   unless permission == "READ" or $org_admins.include?(collaborator.downcase) then

--- a/permissions-report/permissions-report.rb
+++ b/permissions-report/permissions-report.rb
@@ -69,10 +69,10 @@ response = HTTParty.get("https://api.github.com/orgs/jenkinsci/members?role=admi
   "User-Agent" => "JenkinsCI report"
 })
 
-$org_admins = response.parsed_response.map{|user| user["login"]&.downcase}
+$org_admins = response.parsed_response.map{|user| user["login"]}
 
 def record_collaborator(repo_name, collaborator, permission)
-  unless permission == "READ" or $org_admins.include?(collaborator.downcase) then
+  unless permission == "READ" or $org_admins.include? collaborator then
     $table_data << [ repo_name, collaborator, permission ]
   end
 end

--- a/permissions-report/permissions-report.rb
+++ b/permissions-report/permissions-report.rb
@@ -1,18 +1,18 @@
 # Usage: GITHUB_API_TOKEN=abcdefabcdef ruby permission-report.rb > report.json
 
-require "graphql/client"
-require "graphql/client/http"
-require "httparty"
-require "pp"
-require "json"
+require 'graphql/client'
+require 'graphql/client/http'
+require 'httparty'
+require 'pp'
+require 'json'
 
-$auth = "bearer #{ENV["GITHUB_API_TOKEN"]}"
+$auth = "bearer #{ENV['GITHUB_API_TOKEN']}"
 
 module GitHubGraphQL
-  HTTP = GraphQL::Client::HTTP.new("https://api.github.com/graphql") do
+  HTTP = GraphQL::Client::HTTP.new('https://api.github.com/graphql') do
     def headers(context)
       {
-        "Authorization" => $auth
+        'Authorization' => $auth
       }
     end
   end
@@ -64,15 +64,15 @@ GRAPHQL
 
 $table_data = []
 
-response = HTTParty.get("https://api.github.com/orgs/jenkinsci/members?role=admin", :headers => {
-  "Authorization" => $auth,
-  "User-Agent" => "JenkinsCI report"
+response = HTTParty.get('https://api.github.com/orgs/jenkinsci/members?role=admin', :headers => {
+  'Authorization' => $auth,
+  'User-Agent' => 'JenkinsCI report'
 })
 
-$org_admins = response.parsed_response.map{|user| user["login"]}
+$org_admins = response.parsed_response.map{|user| user['login']}
 
 def record_collaborator(repo_name, collaborator, permission)
-  unless permission == "READ" or $org_admins.include? collaborator then
+  unless permission == 'READ' or $org_admins.include? collaborator then
     $table_data << [ repo_name, collaborator, permission ]
   end
 end
@@ -94,8 +94,8 @@ loop do
     sleep 5
     if error_count > 5 then
       # fatal
-      STDERR.puts "Consecutive error count limit reached, aborting"
-      abort("Too many errors")
+      STDERR.puts 'Consecutive error count limit reached, aborting'
+      abort('Too many errors')
     else
       error_count += 1
     end

--- a/permissions-report/permissions-report.rb
+++ b/permissions-report/permissions-report.rb
@@ -63,9 +63,11 @@ GRAPHQL
 
 $table_data = []
 
+# TODO: obtain list of org admins to filter from output
+$org_admins = %w(olivergondza jenkinsadmin rtyler kohsuke daniel-beck oleg-nenashev batmat).map(&:downcase)
+
 def record_collaborator(repo_name, collaborator, permission)
-  # TODO: obtain list of org admins to filter from output
-  if permission != "READ" and collaborator != "olivergondza" and collaborator != "jenkinsadmin" and collaborator != "rtyler" and collaborator != "kohsuke" and collaborator != "daniel-beck" and collaborator != "oleg-nenashev" then
+  unless permission == "READ" or $org_admins.include?(collaborator.downcase) then
     $table_data << [ repo_name, collaborator, permission ]
   end
 end


### PR DESCRIPTION
@daniel-beck I updated the permission report to use API v3 to fetch org admins since it allows filtering based on role.
GitHub GraphQL is sadly not there yet.

This will exclude @batmat as an org admin on the permission report or any new admins added to the org list :sweat_smile: 

I decided to use `unless` to avoid `!=` or `!` logic.

https://jenkins.io/doc/developer/publishing/source-code-hosting/

Tested through irb
```
irb(main):001:0> require 'httparty'
=> true
irb(main):002:0> $auth = "bearer #{ENV['GITHUB_API_TOKEN']}"
=> "bearer SNIP"
irb(main):003:0> response = HTTParty.get("https://api.github.com/orgs/jenkinsci/members?role=admin", :headers => {
irb(main):004:2*   "Authorization" => $auth,
irb(main):005:2*   "User-Agent" => "JenkinsCI report"
irb(main):006:2> })
=> SNIP response
irb(main):007:0> $org_admins = response.parsed_response.map{|user| user['login']&.downcase}
=> ["batmat", "daniel-beck", "jenkinsadmin", "kohsuke", "oleg-nenashev", "olivergondza", "rtyler"]
```