### PR TITLE
Require docker&&linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 				}
 			}
 			agent {
-				label 'docker'
+				label 'docker&&linux'
 			}
 			steps {
 				sh 'docker build permissions-report -t permissions-report'
@@ -41,7 +41,7 @@ pipeline {
 			parallel {
 				stage('Artifactory Permissions') {
 					agent {
-						label 'docker'
+						label 'docker&&linux'
 					}
 					environment {
 						ARTIFACTORY_AUTH = credentials('artifactoryAdmin')
@@ -55,7 +55,7 @@ pipeline {
 				}
 				stage('GitHub Permissions') {
 					agent {
-						label 'docker'
+						label 'docker&&linux'
 					}
 					environment {
 						GITHUB_API = credentials('github-token')

--- a/permissions-report/Dockerfile
+++ b/permissions-report/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-slim
+FROM ruby:2.5-slim
 
 RUN gem install graphql-client httparty
 

--- a/permissions-report/Dockerfile
+++ b/permissions-report/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-slim
+FROM ruby:2.4-slim
 
 RUN gem install graphql-client httparty
 


### PR DESCRIPTION
When Windows docker agents are available, we want to make sure this only runs on Linux docker agents.