### PR TITLE
Fix report generation

### DIFF
--- a/permissions-report/Dockerfile
+++ b/permissions-report/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-slim
+FROM ruby:2.6.5-alpine3.10
 
 RUN gem install graphql-client httparty
 


### PR DESCRIPTION
It was previously failing because one of the graphql client's dependencies doesn't support ruby 2.3 anymore:
https://ci.jenkins.io/job/Infra/job/infra-reports/job/master/45696/console
```
21:43:54  [91mERROR:  Error installing graphql-client:
21:43:54  	There are no versions of zeitwerk (~> 2.2) compatible with your Ruby & RubyGems. Maybe try installing an older version of the gem you're looking for?
21:43:54  	zeitwerk requires Ruby version >= 2.4.4. The current ruby version is 2.3.8.459.
21:43:54  [0mSuccessfully installed concurrent-ruby-1.1.5
```

cc @daniel-beck 