### PR TITLE
Retain only last 36 hours of attempts to run the job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,8 @@ pipeline {
 	options {
 		// 6 hours timeout combined with lock and inverse precedence to will properly gate the GitHub permissions report
 		timeout(time: 25, unit: 'HOURS')
+                // Retain last 36 hours of attempts
+                buildDiscarder logRotator(numToKeepStr: '36')
 	}
 
 	agent none


### PR DESCRIPTION
Was previously retaining unlimited build results and using significant disc space to do it.