### PR TITLE
Add report for maintainer information

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,6 +83,20 @@ pipeline {
 						publishReports ([ 'jira-users-report.json' ])
 					}
 				}
+				stage('Maintainers Jira Info') {
+					agent {
+						label 'docker'
+					}
+					environment {
+						JIRA_AUTH = credentials('jiraAuth')
+					}
+					steps {
+						sh 'docker build maintainers-info-report -t maintainers-info-report'
+						sh 'docker run -e JIRA_AUTH=$JIRA_AUTH maintainers-info-report > maintainers-info-report.json'
+						archiveArtifacts 'maintainers-info-report.json'
+						publishReports ([ 'maintainers-info-report.json' ])
+					}
+				}
 				stage('GitHub Permissions') {
 					agent {
 						label 'docker'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
 				sh 'docker build permissions-report -t permissions-report'
 				sh 'docker build artifactory-users-report -t artifactory-users-report'
 				sh 'docker build jira-users-report -t jira-users-report'
+				sh 'docker build maintainers-info-report -t maintainers-info-report'
 			}
 		}
 

--- a/maintainers-info-report/Dockerfile
+++ b/maintainers-info-report/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:stable-slim
+
+RUN apt-get update
+RUN apt-get install -y wget curl
+
+COPY maintainers-info-report.sh /
+RUN chmod +x /maintainers-info-report.sh
+
+ENTRYPOINT [ "/maintainers-info-report.sh" ]

--- a/maintainers-info-report/maintainers-info-report.sh
+++ b/maintainers-info-report/maintainers-info-report.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+wget -q -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 || { echo "Failed to download jq" >&2 ; exit 1 ; }
+chmod +x jq || { echo "Failed to make jq executable" >&2 ; exit 1 ; }
+
+LIST_URL='https://reports.jenkins.io/maintainers.index.json'
+echo "Querying URL: $LIST_URL" >&2
+curl --silent --fail -u "$JIRA_AUTH" "$LIST_URL" > maintainers.index.json
+
+declare -a MAINTAINERS_LIST
+output="$( ./jq --raw-output '.[][]' maintainers.index.json | sort -u )" # Despite INFRA-2924 we can use raw because maintainers cannot have spaces per RPU
+readarray -t MAINTAINERS_LIST <<< "$output"
+
+echo '' > jira-users-list-tmp.json # clear file from any previous executions
+for USERNAME in "${MAINTAINERS_LIST[@]}" ; do
+
+  URL="https://issues.jenkins.io/rest/api/2/user?username=$USERNAME"
+  echo "Querying URL: $URL" >&2
+  curl --silent --fail -u "$JIRA_AUTH" "$URL" > jira-user-tmp.json
+
+  ./jq '{ name, displayName }' jira-user-tmp.json >> jira-users-list-tmp.json
+done
+
+./jq --slurp '.' jira-users-list-tmp.json


### PR DESCRIPTION
Builds on top of https://github.com/jenkins-infra/repository-permissions-updater/pull/1880 to provide display names of maintainers for consumption by update-center2 and the plugin site.

I don't think we're showing emails anywhere, so I'm skipping that bit of metadata.
