### PR TITLE
chore: execute pipeline once per day

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 pipeline {
 
 	triggers {
-		cron('H * * * *')
+		cron('@daily')
 	}
 
 	options {


### PR DESCRIPTION
As this pipeline takes ~7-8h to execute, running hourly is not really practical.

This PRs proposes to run it daily, liminting the workload pressure.

WDYT?