### PR TITLE
feat: use a Github App instead of a github bot user for permissions-report

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,14 +103,16 @@ pipeline {
 						label 'docker&&linux'
 					}
 					environment {
-						GITHUB_API = credentials('github-token')
+						GITHUB_PRIVATE_KEY_B64 = credentials('githubapp-jenkins-infra-reports-private-key-b64')
+						GITHUB_APP_IDENTIFIER = credentials('githubapp-jenkins-infra-reports-app-identifier')
+						GITHUB_ORG_NAME = "jenkinsci"
 					}
 					options {
 						lock(resource: 'github-permissions', inversePrecedence: true)
 					}
 					steps {
 						sh 'docker build permissions-report -t permissions-report'
-						sh 'docker run -e GITHUB_API_TOKEN=$GITHUB_API_PSW permissions-report > github-jenkinsci-permissions-report.json'
+						sh 'docker run -e GITHUB_PRIVATE_KEY_B64 -e GITHUB_APP_IDENTIFIER -e GITHUB_ORG_NAME permissions-report > github-jenkinsci-permissions-report.json'
 						archiveArtifacts 'github-jenkinsci-permissions-report.json'
 						publishReports ([ 'github-jenkinsci-permissions-report.json' ])
 					}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,8 +103,8 @@ pipeline {
 						label 'docker&&linux'
 					}
 					environment {
-						GITHUB_PRIVATE_KEY_B64 = credentials('githubapp-jenkins-infra-reports-private-key-b64')
-						GITHUB_APP_IDENTIFIER = credentials('githubapp-jenkins-infra-reports-app-identifier')
+						GITHUB_APP_PRIVATE_KEY_B64 = credentials('githubapp-jenkins-infra-reports-private-key-b64')
+						GITHUB_APP_ID = credentials('githubapp-jenkins-infra-reports-app-identifier')
 						GITHUB_ORG_NAME = "jenkinsci"
 					}
 					options {
@@ -112,7 +112,7 @@ pipeline {
 					}
 					steps {
 						sh 'docker build permissions-report -t permissions-report'
-						sh 'docker run -e GITHUB_PRIVATE_KEY_B64 -e GITHUB_APP_IDENTIFIER -e GITHUB_ORG_NAME permissions-report > github-jenkinsci-permissions-report.json'
+						sh 'docker run -e GITHUB_APP_PRIVATE_KEY_B64 -e GITHUB_APP_ID -e GITHUB_ORG_NAME permissions-report > github-jenkinsci-permissions-report.json'
 						archiveArtifacts 'github-jenkinsci-permissions-report.json'
 						publishReports ([ 'github-jenkinsci-permissions-report.json' ])
 					}

--- a/README.md
+++ b/README.md
@@ -23,8 +23,14 @@ Format example:
 
 ### Usage
 
+We use a Github App for that, you'll need to define the following environment variables to run the script:
+
+- GITHUB_PRIVATE_KEY_B64: The Github App private key in PEM format, encoded in base64
+- GITHUB_APP_IDENTIFIER: The GitHub App's identifier (type integer) set when registering an app
+- GITHUB_ORG_NAME: The Github organization name (ex: "jenkinsci")
+
 	docker build permissions-report -t permissions-report
-	docker run -e GITHUB_API_TOKEN=1234567890abcdef1234567890abcdef permissions-report
+	docker run -e GITHUB_PRIVATE_KEY_B64 -e GITHUB_APP_IDENTIFIER -e GITHUB_ORG_NAME permissions-report
 
 ## Artifactory Users Report
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Format example:
 
 We use a Github App for that, you'll need to define the following environment variables to run the script:
 
-- GITHUB_PRIVATE_KEY_B64: The Github App private key in PEM format, encoded in base64
-- GITHUB_APP_IDENTIFIER: The GitHub App's identifier (type integer) set when registering an app
+- GITHUB_APP_PRIVATE_KEY_B64: The Github App private key in PEM format, encoded in base64
+- GITHUB_APP_ID: The GitHub App's identifier (type integer) set when registering an app
 - GITHUB_ORG_NAME: The Github organization name (ex: "jenkinsci")
 
 	docker build permissions-report -t permissions-report
-	docker run -e GITHUB_PRIVATE_KEY_B64 -e GITHUB_APP_IDENTIFIER -e GITHUB_ORG_NAME permissions-report
+	docker run -e GITHUB_APP_PRIVATE_KEY_B64 -e GITHUB_APP_ID -e GITHUB_ORG_NAME permissions-report
 
 ## Artifactory Users Report
 

--- a/permissions-report/Dockerfile
+++ b/permissions-report/Dockerfile
@@ -1,6 +1,8 @@
-FROM ruby:3.1.0-alpine
+FROM ruby:3.1.1-alpine3.15
 
-RUN gem install graphql-client httparty
+RUN apk add openssl-dev openssl build-base
+
+RUN gem install graphql-client httparty jwt time openssl base64
 
 COPY permissions-report.rb /
 

--- a/permissions-report/permissions-report.rb
+++ b/permissions-report/permissions-report.rb
@@ -11,9 +11,9 @@ require 'time'
 require 'base64'
 
 # Expects that the private key in PEM format. Converts the newlines
-PRIVATE_KEY = OpenSSL::PKey::RSA.new(Base64.decode64(ENV['GITHUB_PRIVATE_KEY_B64']).gsub('\n', "\n"))
+PRIVATE_KEY = OpenSSL::PKey::RSA.new(Base64.decode64(ENV['GITHUB_APP_PRIVATE_KEY_B64']).gsub('\n', "\n"))
 # The GitHub App's identifier (type integer) set when registering an app.
-APP_IDENTIFIER = ENV['GITHUB_APP_IDENTIFIER']
+APP_IDENTIFIER = ENV['GITHUB_APP_ID']
 # The organization to scan
 GITHUB_ORG_NAME = ENV['GITHUB_ORG_NAME']
 

--- a/permissions-report/permissions-report.rb
+++ b/permissions-report/permissions-report.rb
@@ -1,18 +1,87 @@
-# Usage: GITHUB_API_TOKEN=abcdefabcdef ruby permission-report.rb > report.json
+# Usage: ruby permission-report.rb > report.json
 
 require 'graphql/client'
 require 'graphql/client/http'
 require 'httparty'
 require 'pp'
 require 'json'
+require 'openssl'
+require 'jwt'
+require 'time'
+require 'base64'
 
-$auth = "bearer #{ENV['GITHUB_API_TOKEN']}"
+# Expects that the private key in PEM format. Converts the newlines
+PRIVATE_KEY = OpenSSL::PKey::RSA.new(Base64.decode64(ENV['GITHUB_PRIVATE_KEY_B64']).gsub('\n', "\n"))
+# The GitHub App's identifier (type integer) set when registering an app.
+APP_IDENTIFIER = ENV['GITHUB_APP_IDENTIFIER']
+# The organization to scan
+GITHUB_ORG_NAME = ENV['GITHUB_ORG_NAME']
+
+# Saves the raw payload and converts the payload to JSON format
+def get_payload_request(request)
+  # request.body is an IO or StringIO object
+  # Rewind in case someone already read it
+  request.body.rewind
+  # The raw text of the body is required for webhook signature verification
+  @payload_raw = request.body.read
+  begin
+    @payload = JSON.parse @payload_raw
+  rescue => e
+    fail  "Invalid JSON (#{e}): #{@payload_raw}"
+  end
+end
+
+# Generate a JWT to authenticate the Github App
+def get_jwt
+  @payload = {
+      # The time that this JWT was issued, _i.e._ now.
+      iat: Time.now.to_i,
+
+      # JWT expiration time (10 minute maximum)
+      exp: Time.now.to_i + (10 * 60),
+
+      # Your GitHub App's identifier number
+      iss: APP_IDENTIFIER
+  }
+  
+  # Cryptographically sign the JWT.
+  @jwt = JWT.encode(@payload, PRIVATE_KEY, 'RS256')
+end
+
+$jwt = "Bearer #{get_jwt}"
+$userAgent = "Jenkins Infra Github App permissions-report (id: #{APP_IDENTIFIER})"
+
+# List installation for the Github App (ref: https://docs.github.com/en/rest/reference/apps#list-installations-for-the-authenticated-app)
+response = HTTParty.get('https://api.github.com/app/installations', :headers => {
+  'Authorization' => $jwt,
+  'User-Agent' => $userAgent
+})
+installationsResponse = response.parsed_response
+$installationId = 0
+installationsResponse.each { |installation|
+  if installation['account']['login'] == GITHUB_ORG_NAME then
+    $installationId = installation['id']
+  end
+}
+if $installationId > 0 then
+  STDERR.puts "Running permissions-report on the organization #{GITHUB_ORG_NAME}"
+else
+  abort "Error: no Github App installation for the organization #{GITHUB_ORG_NAME}"
+end
+
+# Retrieve the Installation Access Token of the Github App (ref: https://docs.github.com/en/rest/reference/apps#create-an-installation-access-token-for-an-app)
+response = HTTParty.post("https://api.github.com/app/installations/#{$installationId}/access_tokens", :headers => {
+  'Authorization' => $jwt,
+  'User-Agent' => $userAgent
+})
+$auth = "Bearer #{response.parsed_response['token']}"
 
 module GitHubGraphQL
   HTTP = GraphQL::Client::HTTP.new('https://api.github.com/graphql') do
     def headers(context)
       {
-        'Authorization' => $auth
+        'Authorization' => $auth,
+        'User-Agent' => $userAgent
       }
     end
   end
@@ -20,12 +89,11 @@ module GitHubGraphQL
   Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
 end
 
-
 CollaboratorsQuery = GitHubGraphQL::Client.parse <<-'GRAPHQL'
 
-query($repository_cursor: String, $collaborator_cursor: String) {
-  organization(login: "jenkinsci") {
-    repositories(first: 10, after: $repository_cursor) {
+query($github_org_name: String!, $repository_cursor: String, $collaborator_cursor: String) {
+  organization(login: $github_org_name) {
+    repositories(first: 10, after: $repository_cursor, privacy: PUBLIC) {
       pageInfo {
         startCursor
         hasNextPage
@@ -64,9 +132,9 @@ GRAPHQL
 
 $table_data = []
 
-response = HTTParty.get('https://api.github.com/orgs/jenkinsci/members?role=admin', :headers => {
+response = HTTParty.get("https://api.github.com/orgs/#{GITHUB_ORG_NAME}/members?role=admin", :headers => {
   'Authorization' => $auth,
-  'User-Agent' => 'JenkinsCI report'
+  'User-Agent' => $userAgent
 })
 
 $org_admins = response.parsed_response.map{|user| user['login']}
@@ -87,7 +155,11 @@ error_count = 0
 
 loop do
   STDERR.puts "Calling with cursors: repository #{repository_cursor}, collaborator #{collaborator_cursor}"
-  result = GitHubGraphQL::Client.query(CollaboratorsQuery, variables: {repository_cursor: repository_cursor, collaborator_cursor: collaborator_cursor})
+  result = GitHubGraphQL::Client.query(CollaboratorsQuery, variables: {
+    github_org_name: GITHUB_ORG_NAME,
+    repository_cursor: repository_cursor,
+    collaborator_cursor: collaborator_cursor
+  })
 
   if !result.errors[:data].empty? then
     STDERR.puts result.errors[:data]


### PR DESCRIPTION
Part of https://github.com/jenkins-infra/helpdesk/issues/2788

A Github App `jenkins-infra-reports` has been created and installed on https://github.com/jenkinsci/ with one permission, "Metadata" as "Read-only", on all repositories.

I've added a parameter to the GraphQL query to return only public repositories.

<strike>@daniel-beck do you know if only public repositories should be queried? It's used for a public view of the plugins so it seems to be the case for me but I don't know if it's used elsewhere.</strike>