### PR TITLE
fix(fork-report,permission-report) pin ruby version to 3.0.4 to avoid using unexpected versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.6.9
+ruby 3.0.4
 nodejs 16.13.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,2 @@
 ruby 3.0.4
 nodejs 16.13.1
-bundle 2.2.33

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 ruby 3.0.4
 nodejs 16.13.1
+bundle 2.2.33

--- a/JenkinsAgentPodTemplate.yaml
+++ b/JenkinsAgentPodTemplate.yaml
@@ -7,10 +7,10 @@ spec:
       name: "jnlp"
       resources:
         limits:
-          memory: "512Mi"
+          memory: "256Mi"
           cpu: "1"
         requests:
-          memory: "512Mi"
+          memory: "256Mi"
           cpu: "1"
       securityContext:
         privileged: false

--- a/JenkinsAgentPodTemplate.yaml
+++ b/JenkinsAgentPodTemplate.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 spec:
   containers:
-    - image: "jenkinsciinfra/builder:2.0.58"
+    - image: "jenkinsciinfra/builder:2.1.0"
       imagePullPolicy: "IfNotPresent"
       name: "jnlp"
       resources:

--- a/JenkinsAgentPodTemplate.yaml
+++ b/JenkinsAgentPodTemplate.yaml
@@ -7,10 +7,10 @@ spec:
       name: "jnlp"
       resources:
         limits:
-          memory: "256Mi"
+          memory: "768Mi"
           cpu: "1"
         requests:
-          memory: "256Mi"
+          memory: "768Mi"
           cpu: "1"
       securityContext:
         privileged: false

--- a/fork-report/Gemfile
+++ b/fork-report/Gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'graphql'
+gem 'graphql-client'
 gem 'httparty'
 gem 'json'

--- a/fork-report/Gemfile.lock
+++ b/fork-report/Gemfile.lock
@@ -20,4 +20,4 @@ DEPENDENCIES
   json
 
 BUNDLED WITH
-   1.17.2
+   2.2.33

--- a/fork-report/Gemfile.lock
+++ b/fork-report/Gemfile.lock
@@ -1,21 +1,35 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    graphql (2.0.11)
+    activesupport (7.0.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    concurrent-ruby (1.1.10)
+    graphql (2.0.12)
+    graphql-client (0.18.0)
+      activesupport (>= 3.0)
+      graphql
     httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     json (2.6.2)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
+    minitest (5.16.2)
     multi_xml (0.6.0)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  graphql
+  graphql-client
   httparty
   json
 

--- a/permissions-report/Gemfile
+++ b/permissions-report/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'graphql'
+gem 'graphql-client'
 gem 'httparty'
 gem 'json'
 gem 'openssl'

--- a/permissions-report/Gemfile.lock
+++ b/permissions-report/Gemfile.lock
@@ -30,4 +30,4 @@ DEPENDENCIES
   time
 
 BUNDLED WITH
-   1.17.2
+   2.2.33


### PR DESCRIPTION
This PR fixes the failures introduces by #43 which downgraded accidentally the ruby version from 3.0.x to 2.9.6.

The following changes are introduced:

- Pin the Ruby version to 3.0.4 in the ASDF `.tools-version` file
  - Before #43, https://github.com/jenkins-infra/docker-helmfile/blob/main/Dockerfile#L83-L89 was used for ruby: 3.0 stable line
  - As per https://www.ruby-lang.org/en/downloads/, Ruby 3.0.4 is the latest stable version for the 3.0 line
  - The former `2.6.9` version for ruby was not used in this repository as far as I can tell.
- Bumped `jenkinsciinfra/builder` to `2.1.0` to provide a Ruby 3.0.4 pre-installed system (as explained in https://github.com/jenkins-infra/docker-builder/pull/73#issuecomment-1190288049)
- Upgraded the `Gemfile.lock` to use the version `2.2.33` of `bundler` (packaged by default with Ruby 3.0.4)
  - Bundler 1.17.12 was specified prior to this PR. Not sure why
- Correct the 2 `Gemfile`s to use the dependency `graphql-client` instead of `graphql`
  - Before #43, gems were installed in https://github.com/jenkins-infra/docker-helmfile/blob/631625054ffaad63918f791b9668a72674229fea/Dockerfile#L88` and the `bundle install` was only adding more dependencies ( e.g. `graphql` which was never used)
- Increased the memory allocated for the agent to avoid OOM kills (exit code with error 137)
  - Was `256M`, which can be reproduced locally. But there is also the `agent.jar` process which already consumes ~500 Mb by itself
