### PR TITLE
fix(jenkins-infra-report): fail if the source doesn't return any mirror

### DIFF
--- a/jenkins-infra-data/get-jenkins-io_mirrors.sh
+++ b/jenkins-infra-data/get-jenkins-io_mirrors.sh
@@ -24,6 +24,11 @@ continentXPath="//td[5]"
 
 mirrorRows=$(curl --silent --max-redirs 2 --request GET --location "${source}" | xq --node --xpath "${mirrorRowXPath}")
 
+if [[ -z ${mirrorRows} ]]; then
+    echo "Error: no mirror returned from ${source}"
+    exit 1
+fi
+
 readarray -t names <<< "$(echo "${mirrorRows}" | xq --xpath "${nameXPath}" || true)"
 readarray -t urls <<< "$(echo "${mirrorRows}" | xq --xpath "${urlXPath}" || true)"
 readarray -t countries <<< "$(echo "${mirrorRows}" | xq --xpath "${countryXPath}" || true)"


### PR DESCRIPTION
This PR adds a check to fail the script if the source doesn't return any mirror like it was the case yesterday (see https://github.com/jenkins-infra/helpdesk/issues/3927)

Follow-up of:
- #55 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3832#issuecomment-1917184500