### PR TITLE
chore(pipeline::plugin-migration): rename stage not to override the other pipeline (Generate GitHub Permissions Report)

### DIFF
--- a/plugin-migration/Jenkinsfile
+++ b/plugin-migration/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     }
   }
   stages {
-    stage('Generate Plugin-Migration Report') {
+    stage('Generate Plugin Documentation Migration Report') {
         environment {
             GITHUB_APP_PRIVATE_KEY_B64 = credentials('githubapp-jenkins-infra-reports-private-key-b64')
             GITHUB_APP_ID = credentials('githubapp-jenkins-infra-reports-app-identifier')

--- a/plugin-migration/Jenkinsfile
+++ b/plugin-migration/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     }
   }
   stages {
-    stage('Generate GitHub Permissions Report') {
+    stage('Generate Plugin-Migration Report') {
         environment {
             GITHUB_APP_PRIVATE_KEY_B64 = credentials('githubapp-jenkins-infra-reports-private-key-b64')
             GITHUB_APP_ID = credentials('githubapp-jenkins-infra-reports-app-identifier')


### PR DESCRIPTION
wrong name that override the other one