### PR TITLE
feat: private instances report

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,20 @@ This requires curl(1), jq(1) and xq(1) command line tools.
 cd jenkins-infra-data/
 ./get-jenkins-io_mirrors.sh
 ```
+
+## Private Instances Report
+
+Creates a report listing all jobs with their last build and the build queue of a private Jenkins instance.
+
+### Usage
+
+You'll need to define the following environment variables to run the script:
+
+- INSTANCE_NAME: The name of the instance, ex "trusted.ci.jenkins.io"
+- INSTANCE_TOKEN: Jenkins username and token separated by `:`, ex: "myuser:mytoken"
+- REPORT_NAME: The filename of the report, ex "trusted.json"
+
+```bash
+cd private-instances-report
+./get-private-instance-jobs-and-queue.sh
+```

--- a/private-instances-report/Jenkinsfile
+++ b/private-instances-report/Jenkinsfile
@@ -1,0 +1,70 @@
+def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/10 * * * *' : ''
+def version = 'v1'
+def reportFolder = "private-instances/${version}"
+
+pipeline {
+  triggers {
+    cron(cronExpr)
+  }
+  options {
+    timeout(time: 10, unit: 'MINUTES')
+    lock(resource: 'private-instances', inversePrecedence: true)
+    buildDiscarder logRotator(daysToKeepStr: '90')
+  }
+  agent none
+  stages {
+    stage('Private Instances report') {
+      matrix {
+        axes {
+          axis {
+            name 'INSTANCE_NAME'
+            values 'trusted.ci.jenkins.io', 'release.ci.jenkins.io', 'infra.ci.jenkins.io'
+          }
+        }
+        agent {
+          label 'jnlp-linux-arm64'
+        }
+        when {
+          // Report trusted.ci.jenkins.io instance only from trusted.ci.jenkins.io
+          anyOf {
+            expression { env.JENKINS_URL.startsWith("https://${INSTANCE_NAME}") }
+            expression { INSTANCE_NAME != 'trusted.ci.jenkins.io' }
+          }
+        }
+        environment {
+          VERSION = "${version}"
+          INSTANCE_TOKEN = credentials("private-instances-report-token-${INSTANCE_NAME}")
+          REPORT_NAME = "${INSTANCE_NAME}.json"
+          REPORT_FOLDER = "${reportFolder}"
+        }
+        stages {
+          stage('Generate report') {
+            steps {
+              dir('private-instances-report') {
+                sh '''
+                # Generate the report
+                ./get-private-instance-jobs-and-queue.sh
+
+                # Copy the report to the desired folder for getting an apppropriate report URL
+                mkdir -p "${REPORT_FOLDER}"
+                cp "${REPORT_NAME}" "${REPORT_FOLDER}"
+                '''
+                archiveArtifacts artifacts: "${REPORT_NAME}"
+              }
+            }
+          }
+          stage('Publish report') {
+            when {
+              expression { env.BRANCH_IS_PRIMARY }
+            }
+            steps {
+              dir('private-instances-report') {
+                publishReports (["${reportFolder}/${REPORT_NAME}"])
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/private-instances-report/get-private-instance-jobs-and-queue.sh
+++ b/private-instances-report/get-private-instance-jobs-and-queue.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -x
+
+: "${INSTANCE_NAME?}" "${INSTANCE_TOKEN?}" "${REPORT_NAME?}"
+
+command -v "jq" >/dev/null || { echo "[ERROR] no 'jq' command found."; exit 1; }
+
+function urlencode() {
+    encoded=$(jq --raw-output --null-input --arg x "$1" '$x|@uri')
+    echo "${encoded}"
+}
+
+version=${VERSION:-v1}
+lastUpdate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+jobFields="fullDisplayName,url,color,labelExpression"
+queueFields="blocked,stuck,why,inQueueSince,buildableStartMilliseconds"
+buildFields="fullDisplayName,url,result,timestamp,duration,estimatedDuration,inProgress,builtOn"
+
+# Traverse and retrieve all jobs and their last build
+jobsQuery="jobs[${jobFields},builds[${buildFields}]{0},jobs[${jobFields},builds[${buildFields}]{0},jobs[${jobFields},builds[${buildFields}]{0},jobs[${jobFields},builds[${buildFields}]{0}]]]]"
+# Retrieve job(s) and their last build (if any) from queue
+queueQuery="items[${queueFields},task[${jobFields},builds[${buildFields}]{0}]]"
+
+jobsQueryUrl="https://${INSTANCE_NAME}/api/json?tree=$(urlencode "${jobsQuery}")"
+queueQueryUrl="https://${INSTANCE_NAME}/queue/api/json?tree=$(urlencode "${queueQuery}")"
+
+# Query the instance and flatten the results
+jobsJSON=$(curl --user "${INSTANCE_TOKEN}" --request GET --location "${jobsQueryUrl}" | jq '.. | select(.color?)' | jq --slurp '.')
+queueJSON=$(curl --user "${INSTANCE_TOKEN}" --request GET --location "${queueQueryUrl}" | jq '.. | select(.why?)' | jq --slurp '.')
+
+# Initialise output with jobs JSON as it can be too big to be passed as argjson to jq(1)
+json="{\"jobs\": ${jobsJSON}}"
+# Add current date and API version to the instance jobs and queue
+json=$(echo "${json}" | jq \
+        --argjson queue "${queueJSON}" \
+        --arg jobsQueryUrl "${jobsQueryUrl}" \
+        --arg queueQueryUrl "${queueQueryUrl}" \
+        --arg lastUpdate "${lastUpdate}" \
+        --arg version "${version}" \
+        '. += {"queue": $queue, "jobsQueryUrl": $jobsQueryUrl, "queueQueryUrl": $queueQueryUrl, "lastUpdate": $lastUpdate, "version": $version}')
+
+echo "${json}" > "${REPORT_NAME}"


### PR DESCRIPTION
This PR adds a report for each of Jenkins private instances, containing their jobs and their last build (cf https://github.com/jenkins-infra/helpdesk/issues/2843#issuecomment-1082167461), and the build queue.

For the trusted.ci.jenkins.io report, the job has to be configured on trusted.ci.jenkins.io too, hence the `when` block to run only for this report in that case.

I manually added corresponding infra-report job and credentials on infra.ci.jenkins.io for testing purpose, they need to be created as code.

~Resulting artifacts:~
- ~https://infra.ci.jenkins.io/job/reports/job/Private%20Instances%20Report/view/change-requests/job/PR-62/9/artifact/infra.ci.jenkins.io.json~
- ~https://infra.ci.jenkins.io/job/reports/job/Private%20Instances%20Report/view/change-requests/job/PR-62/9/artifact/release.ci.jenkins.io.json~

Flattened resulting artifacts:
- https://infra.ci.jenkins.io/job/reports/job/Private%20Instances%20Report/view/change-requests/job/PR-62/11/artifact/infra.ci.jenkins.io.json
- https://infra.ci.jenkins.io/job/reports/job/Private%20Instances%20Report/view/change-requests/job/PR-62/11/artifact/release.ci.jenkins.io.json

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2843#issuecomment-1075145450
- https://github.com/jenkins-infra/helpdesk/issues/3592