### PR TITLE
chore(fork-report,permissions-report) bump Ruby to 3.3.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.2.3
+ruby 3.3.0
 nodejs 20.11.1

--- a/fork-report/Gemfile.lock
+++ b/fork-report/Gemfile.lock
@@ -1,28 +1,37 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3.1)
+    activesupport (7.1.3.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-    concurrent-ruby (1.1.10)
-    graphql (2.0.12)
-    graphql-client (0.18.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.7)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
+    drb (2.2.1)
+    graphql (2.3.0)
+      base64
+    graphql-client (0.21.0)
       activesupport (>= 3.0)
-      graphql
-    httparty (0.20.0)
-      mime-types (~> 3.0)
+      graphql (>= 1.13.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.12.0)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
-    json (2.6.2)
-    mime-types (3.4.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
-    minitest (5.16.2)
+    json (2.7.2)
+    mini_mime (1.1.5)
+    minitest (5.22.3)
     multi_xml (0.6.0)
-    tzinfo (2.0.5)
+    mutex_m (0.2.0)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
 PLATFORMS

--- a/fork-report/Gemfile.lock
+++ b/fork-report/Gemfile.lock
@@ -34,4 +34,4 @@ DEPENDENCIES
   json
 
 BUNDLED WITH
-   2.4.1
+   2.5.7

--- a/permissions-report/Gemfile.lock
+++ b/permissions-report/Gemfile.lock
@@ -44,4 +44,4 @@ DEPENDENCIES
   time
 
 BUNDLED WITH
-   2.4.1
+   2.5.7

--- a/permissions-report/Gemfile.lock
+++ b/permissions-report/Gemfile.lock
@@ -1,32 +1,41 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.3)
+    activesupport (7.1.3.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-    base64 (0.1.1)
-    concurrent-ruby (1.2.2)
-    date (3.2.2)
-    graphql (2.0.20)
-    graphql-client (0.18.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.7)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
+    date (3.3.4)
+    drb (2.2.1)
+    graphql (2.3.0)
+      base64
+    graphql-client (0.21.0)
       activesupport (>= 3.0)
-      graphql
-    httparty (0.20.0)
-      mime-types (~> 3.0)
+      graphql (>= 1.13.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.12.0)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
-    json (2.6.2)
-    jwt (2.4.1)
-    mime-types (3.4.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
-    minitest (5.18.0)
+    json (2.7.2)
+    jwt (2.8.1)
+      base64
+    mini_mime (1.1.5)
+    minitest (5.22.3)
     multi_xml (0.6.0)
-    openssl (3.0.0)
-    time (0.2.0)
+    mutex_m (0.2.0)
+    openssl (3.2.0)
+    time (0.3.0)
       date
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
The main branch is failing for both `fork-report` and `permissions-report` since the 11 of March.

It's because [we deployed a new agent template version](https://github.com/jenkins-infra/kubernetes-management/pull/5041), version [1.56.0 which features Ruby 3.3.0](https://github.com/jenkins-infra/packer-images/releases/tag/1.56.0).


This PR is a first step to fix the report generation by using the current Ruby version: 3.3.0.


For each changed sub project, after changing the local Ruby version to 3.3.0, I ran the `bundle update --ruby --bundler` command to ensure `Gemfile` and `Gemfile.lock` are updated.