### PR TITLE
chore: track Ruby and NodeJS ASDF tool versions with updatecli

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,0 +1,4 @@
+updatecli(action: 'diff')
+if (env.BRANCH_IS_PRIMARY) {
+    updatecli(action: 'apply', cronTriggerExpression: '@weekly')
+}

--- a/updatecli/updatecli.d/nodejs.yaml
+++ b/updatecli/updatecli.d/nodejs.yaml
@@ -1,0 +1,55 @@
+name: Bump NodeJS version in ASDF tools
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getInfraCIPackerImageVersion:
+    kind: file
+    name: Retrieve the current version of the Packer images used in production on infra.ci.jenkins.io
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/kubernetes-management/main/config/jenkins_infra.ci.jenkins.io.yaml
+      # Prefiltering to avoid verbose output
+      matchpattern: 'galleryImageVersion:\s"(.*)"'
+    transformers:
+      - findsubmatch:
+          pattern: 'galleryImageVersion:\s"(.*)"'
+          captureindex: 1
+  getNodeJSVersionFromPackerImages:
+    kind: yaml
+    name: Get the latest NodeJS version set in packer-images
+    dependson:
+      - getInfraCIPackerImageVersion
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getInfraCIPackerImageVersion" }}/provisioning/tools-versions.yml
+      key: $.nodejs_linux_version
+
+targets:
+  updateAsdfToolsVersion:
+    name: Update NodeJS in the ASDF tools version file
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: .tool-versions
+      matchpattern: 'nodejs\s(.*)'
+      replacepattern: 'nodejs {{ source "getNodeJSVersionFromPackerImages" }}'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump NodeJS version in ASDF tools to {{ source "getNodeJSVersionFromPackerImages" }}
+      labels:
+        - chore
+        - nodejs

--- a/updatecli/updatecli.d/ruby.yaml
+++ b/updatecli/updatecli.d/ruby.yaml
@@ -1,0 +1,55 @@
+name: Bump Ruby version in ASDF tools
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getInfraCIPackerImageVersion:
+    kind: file
+    name: Retrieve the current version of the Packer images used in production on infra.ci.jenkins.io
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/kubernetes-management/main/config/jenkins_infra.ci.jenkins.io.yaml
+      # Prefiltering to avoid verbose output
+      matchpattern: 'galleryImageVersion:\s"(.*)"'
+    transformers:
+      - findsubmatch:
+          pattern: 'galleryImageVersion:\s"(.*)"'
+          captureindex: 1
+  getRubyVersionFromPackerImages:
+    kind: yaml
+    name: Get the latest Ruby version set in packer-images
+    dependson:
+      - getInfraCIPackerImageVersion
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getInfraCIPackerImageVersion" }}/provisioning/tools-versions.yml
+      key: $.ruby_version
+
+targets:
+  updateAsdfToolsVersion:
+    name: Update Ruby in the ASDF tools version file
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: .tool-versions
+      matchpattern: 'ruby\s(.*)'
+      replacepattern: 'ruby {{ source "getRubyVersionFromPackerImages" }}'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump Ruby version in ASDF tools to {{ source "getRubyVersionFromPackerImages" }}
+      labels:
+        - chore
+        - ruby

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,7 @@
+github:
+  user: "Jenkins Infra Bot (updatecli)"
+  email: "60776566+jenkins-infra-bot@users.noreply.github.com"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "main"
+  owner: "jenkins-infra"
+  repository: "infra-reports"


### PR DESCRIPTION
This PR introduces `updatecli` manifests to track the version of Ruby and NodeJS available in the infra.ci.jenkins.io agents.

Once merged, 2 new PRs are expected to be created to bump versions.

Note: Ruby version must be upgraded in order to fix the currently failing reports