### PR TITLE
chore(plugin-healt-scoring): generate report once per hour

### DIFF
--- a/plugin-health-scoring/Jenkinsfile
+++ b/plugin-health-scoring/Jenkinsfile
@@ -1,4 +1,4 @@
-def cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
+def cronExpr = env.BRANCH_IS_PRIMARY ? '@hourly' : ''
 def reportsFolder = 'plugin-health-scoring'
 def etagsFile = 'etags.txt'
 def reportFile = env.BRANCH_IS_PRIMARY ? 'scores.json' : "scores-${env.BRANCH_NAME}.json"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3961#issuecomment-2044398913

- The PHS scores are recalculated once per hour
- The Plugin Site is generated once every 3 hours

=> It makes sense to run the PHS report once per hour instead of once per day. Thanks @alecharp 