### PR TITLE
fix: don't take in account ETags for Plugin Health Scoring report

### DIFF
--- a/plugin-health-scoring/Jenkinsfile
+++ b/plugin-health-scoring/Jenkinsfile
@@ -1,6 +1,5 @@
 def cronExpr = env.BRANCH_IS_PRIMARY ? '@hourly' : ''
 def reportsFolder = 'plugin-health-scoring'
-def etagsFile = 'etags.txt'
 def reportFile = env.BRANCH_IS_PRIMARY ? 'scores.json' : "scores-${env.BRANCH_NAME}.json"
 def reportLines = 0
 
@@ -11,7 +10,6 @@ pipeline {
 
   environment {
     REPORTS_FOLDER = "${reportsFolder}"
-    ETAGS_FILE = "${etagsFile}"
     REPORT_FILE = "${reportFile}"
     PHS_API_URL = 'https://plugin-health.jenkins.io/api/scores'
   }

--- a/plugin-health-scoring/fetch-report.sh
+++ b/plugin-health-scoring/fetch-report.sh
@@ -32,20 +32,14 @@ do
 done
 
 : "${REPORTS_FOLDER?Environment variable 'REPORTS_FOLDER' unset}"
-: "${ETAGS_FILE?Environment variable 'REPORTS_FOLDER' unset}"
-: "${REPORT_FILE?Environment variable 'REPORTS_FOLDER' unset}"
+: "${REPORT_FILE?Environment variable 'REPORT_FILE' unset}"
 : "${PHS_API_URL?Environment variable 'PHS_API_URL' unset}"
-
-# Pre-check for etags
-curl --location --silent --show-error --remote-name "https://reports.jenkins.io/${REPORTS_FOLDER}/${ETAGS_FILE}" || echo "No previous etags file."
 
 ###
 # using --compact-output to reduce output file by half.
 # adding report generation date in 'lastUpdate' key of the report.
 ###
-curl --etag-compare "${ETAGS_FILE}" \
-    --etag-save "${ETAGS_FILE}" \
-    --location --fail --silent --show-error "${PHS_API_URL}" \
+curl --location --fail --silent --show-error "${PHS_API_URL}" \
     | jq --compact-output '. + { lastUpdate: (now | todate) }' > "${REPORT_FILE}"
 
 mkdir -p "${REPORTS_FOLDER}"


### PR DESCRIPTION
This PR removes the check with ETags, not mandatory and preventing to fetch PHS API results (reproduced locally).

