### PR TITLE
chore(jenkins-infra-data) make shell portable + add wrapper script to avoid data loss during partial updates

### DIFF
--- a/jenkins-infra-data/Jenkinsfile
+++ b/jenkins-infra-data/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
     label 'jnlp-linux-arm64'
   }
   environment {
-    DIST_DIR = "${WORKSPACE}/dist"
+    DIST_DIR = "${WORKSPACE}/jenkins-infra-data/dist"
     PUBLISHED_REPORT = "${reportFolder}/${reportName}"
     REPORT_FOLDER = "${reportFolder}"
     REPORT_NAME = "${reportName}"
@@ -35,8 +35,9 @@ pipeline {
       steps {
         dir('jenkins-infra-data') {
           sh './generate-infra-data.sh "${REPORT_NAME}" "${DIST_DIR}" "${VERSION}"'
+          sh 'ls -ltr "${DIST_DIR}"'
 
-          archiveArtifacts artifacts: "${env.DIST_DIR}/**/*"
+          archiveArtifacts artifacts: env.DIST_DIR
         }
       }
     }

--- a/jenkins-infra-data/Jenkinsfile
+++ b/jenkins-infra-data/Jenkinsfile
@@ -25,6 +25,13 @@ pipeline {
   }
   stages {
     stage('Generate Jenkins Infrastructure Public Data report') {
+      when {
+        // Build only on principal branch, or if a change was found in the directory 'jenkins-infra-data/'
+        anyOf {
+          changeset 'jenkins-infra-data/**/*'
+          expression { env.BRANCH_IS_PRIMARY }
+        }
+      }
       steps {
         dir('jenkins-infra-data') {
           sh './generate-infra-data.sh "${REPORT_NAME}" "${DIST_DIR}" "${VERSION}"'

--- a/jenkins-infra-data/Jenkinsfile
+++ b/jenkins-infra-data/Jenkinsfile
@@ -1,6 +1,5 @@
 def cronExpr = env.BRANCH_IS_PRIMARY ? '@hourly' : ''
 def reportName = 'index.json'
-def sourceHTML = 'source.html'
 def version = 'v2'
 def reportFolder = "infrastructure/${version}"
 
@@ -17,30 +16,20 @@ pipeline {
   agent {
     label 'jnlp-linux-arm64'
   }
+  environment {
+    DIST_DIR = "${WORKSPACE}/dist"
+    PUBLISHED_REPORT = "${reportFolder}/${reportName}"
+    REPORT_FOLDER = "${reportFolder}"
+    REPORT_NAME = "${reportName}"
+    VERSION = "${version}"
+  }
   stages {
     stage('Generate Jenkins Infrastructure Public Data report') {
-      environment {
-        VERSION = "${version}"
-        REPORT_NAME = "${reportName}"
-        SOURCE_HTML = "${sourceHTML}"
-        REPORT_FOLDER = "${reportFolder}"
-      }
       steps {
         dir('jenkins-infra-data') {
-          sh '''
-          set +x
-          # Retrieve existing report if it exists, empty object otherwise
-          existing=$(curl --silent --fail --max-redirs 2 --request GET --location "https://reports.jenkins.io/${REPORT_FOLDER}/${REPORT_NAME}" || echo '{}')
-          echo "$existing" > "${REPORT_NAME}"
+          sh './generate-infra-data.sh "${REPORT_NAME}" "${DIST_DIR}" "${VERSION}"'
 
-          # Update the report
-          ./get-jenkins-io_mirrors.sh
-
-          # Copy the report to the desired folder for getting an apppropriate report URL
-          mkdir -p "${REPORT_FOLDER}"
-          cp "${REPORT_NAME}" "${REPORT_FOLDER}"
-          '''
-          archiveArtifacts artifacts: "${sourceHTML}, ${reportName}"
+          archiveArtifacts artifacts: "${env.DIST_DIR}/**/*"
         }
       }
     }
@@ -50,7 +39,13 @@ pipeline {
       }
       steps {
         dir('jenkins-infra-data') {
-          publishReports (["${reportFolder}/${reportName}"])
+          sh '''
+          # Prepare directory/file structure for reports publication
+          mkdir -p "${REPORT_FOLDER}"
+          cp "${DIST_DIR}/${REPORT_NAME}" "${PUBLISHED_REPORT}"
+          '''
+
+          publishReports ([env.PUBLISHED_REPORT])
         }
       }
     }

--- a/jenkins-infra-data/Jenkinsfile
+++ b/jenkins-infra-data/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
           sh './generate-infra-data.sh "${REPORT_NAME}" "${DIST_DIR}" "${VERSION}"'
           sh 'ls -ltr "${DIST_DIR}"'
 
-          archiveArtifacts artifacts: env.DIST_DIR
+          archiveArtifacts artifacts: 'dist/**'
         }
       }
     }

--- a/jenkins-infra-data/generate-infra-data.sh
+++ b/jenkins-infra-data/generate-infra-data.sh
@@ -26,12 +26,12 @@ json='{}'
 lastUpdate="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 getJenkinsIoData="$(./get-jenkins-io_mirrors.sh)"
 # Add current date and API version
-getJenkinsIoData="$(echo "${getJenkinsIoData}" | jq --raw-output0 --compact-output \
+getJenkinsIoData="$(echo "${getJenkinsIoData}" | jq --compact-output \
   --arg lastUpdate "${lastUpdate}" \
   --arg version "${VERSION}" \
   '. += {"lastUpdate": $lastUpdate, "version": $version}')"
 echo "${json}"
-json="$(echo "${json}" | jq --raw-output0 --compact-output \
+json="$(echo "${json}" | jq --compact-output \
   --argjson getJenkinsIoData "${getJenkinsIoData}" \
   '. + {"get.jenkins.io": $getJenkinsIoData}' \
 )"

--- a/jenkins-infra-data/generate-infra-data.sh
+++ b/jenkins-infra-data/generate-infra-data.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# generate-infra-data.sh: Generate a JSON report named $1 in the directory $2 (with a optional version $3).
+#  Note: This script orchestrate generation by "parts": there are sub-scripts per services which generate partial content.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+set -x
+
+REPORT_NAME="$1"
+test -n "${REPORT_NAME}"
+DIST_DIR="$2"
+test -n "${DIST_DIR}"
+mkdir -p "${DIST_DIR}"
+# Sub scripts need this
+export DIST_DIR
+VERSION="${3:-v1}"
+
+command -v "date" >/dev/null || { echo "[ERROR] no 'jq' command found."; exit 1; }
+command -v "jq" >/dev/null || { echo "[ERROR] no 'jq' command found."; exit 1; }
+
+json='{}'
+
+## get.jenkins.io
+# BSD Date and GNU Date have the same behavior with this pattern
+lastUpdate="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+getJenkinsIoData="$(./get-jenkins-io_mirrors.sh)"
+# Add current date and API version
+getJenkinsIoData="$(echo "${getJenkinsIoData}" | jq --raw-output0 --compact-output \
+  --arg lastUpdate "${lastUpdate}" \
+  --arg version "${VERSION}" \
+  '. += {"lastUpdate": $lastUpdate, "version": $version}')"
+echo "${json}"
+json="$(echo "${json}" | jq --raw-output0 --compact-output \
+  --argjson getJenkinsIoData "${getJenkinsIoData}" \
+  '. + {"get.jenkins.io": $getJenkinsIoData}' \
+)"
+
+## Write report
+echo "${json}" > "${DIST_DIR}/${REPORT_NAME}"

--- a/jenkins-infra-data/get-jenkins-io_mirrors.sh
+++ b/jenkins-infra-data/get-jenkins-io_mirrors.sh
@@ -2,17 +2,17 @@
 
 set -o nounset
 set -o errexit
+set -o pipefail
 set -x
 
 command -v "jq" >/dev/null || { echo "[ERROR] no 'jq' command found."; exit 1; }
 command -v "xq" >/dev/null || { echo "[ERROR] no 'xq' command found."; exit 1; }
 command -v "dig" >/dev/null || { echo "[ERROR] no 'dig' command found."; exit 1; }
 
-version=${VERSION:-v1}
-reportName=${REPORT_NAME:-index.json}
-sourceHTML=${SOURCE_HTML:-source.html}
+test -d "${DIST_DIR}"
+
+sourceHTML="${DIST_DIR}"/source.html
 source="https://get.jenkins.io/index.html?mirrorstats"
-lastUpdate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 mirrorTableQuery="body > div > div > div > table"
 mirrorRowXPath="//table/tbody/tr"
@@ -23,40 +23,33 @@ fallback="archives.jenkins.io"
 curl --silent --max-redirs 2 --request GET --location "${source}" --output "${sourceHTML}"
 
 # Retrieving all rows of the table containing all mirrors
-mirrorRows=$(xq --node --query "${mirrorTableQuery}" "${sourceHTML}" | xq --node --xpath "${mirrorRowXPath}")
+mirrorRows="$(xq --node --query "${mirrorTableQuery}" "${sourceHTML}" | xq --node --xpath "${mirrorRowXPath}")"
 
-if [[ -z ${mirrorRows} ]]; then
+if [[ -z "${mirrorRows}" ]]; then
     echo "Error: no mirror returned from ${source}"
     exit 1
 fi
 
-# Keep only cells not finishing by " ago" (last update column) and that are not the fallback mirror
-readarray -t hostnames <<< "$(echo "${mirrorRows}" | xq --xpath "${cellXPath}" | grep -v ' ago' | grep -v "${fallback}" || true)"
+# Retrieve list of hostnames, one per line. Keep only cells not finishing by " ago" (last update column) and that are not the fallback mirror.
+hostnames="$(echo "${mirrorRows}" | xq --xpath "${cellXPath}" | grep -v ' ago' | grep -v "${fallback}")"
 
 json='{"mirrors": []}'
-for ((i=0; i<${#hostnames[@]}; i++)); do
+while IFS= read -r hostname
+do
     # As dig(1) can returns CNAME values, we need to filter IPs from its result(s) (those not finishing by a ".")
-    ipv4=$(dig +short "${hostnames[i]}" A | jq --raw-input --slurp 'split("\n") | map(select(test("\\.$") | not)) | map(select(length > 0))')
-    ipv6=$(dig +short "${hostnames[i]}" AAAA | jq --raw-input --slurp 'split("\n") | map(select(test("\\.$") | not)) | map(select(length > 0))')
-    json=$(echo "${json}" | jq \
-        --arg hostname "${hostnames[i]}" \
+    ipv4="$(dig +short "${hostname}" A | jq --raw-input --slurp 'split("\n") | map(select(test("\\.$") | not)) | map(select(length > 0))')"
+    ipv6="$(dig +short "${hostname}" AAAA | jq --raw-input --slurp 'split("\n") | map(select(test("\\.$") | not)) | map(select(length > 0))')"
+    json="$(echo "${json}" | jq \
+        --arg hostname "${hostname}" \
         --argjson ipv4 "${ipv4}" \
         --argjson ipv6 "${ipv6}" \
-        '.mirrors |= . + [{"hostname": $hostname, "ipv4": $ipv4, "ipv6": $ipv6}]')
-done
+        '.mirrors |= . + [{"hostname": $hostname, "ipv4": $ipv4, "ipv6": $ipv6}]')"
+done <<< "${hostnames}"
 
-if [[ ${i} -eq 0 ]]; then
+if [[ "${json}" == '{"mirrors": []}' ]]; then
     echo "Error: no mirror returned from ${source}"
     exit 1
 fi
 
-# Add current date and API version
-json=$(echo "${json}" | jq \
-        --arg lastUpdate "${lastUpdate}" \
-        --arg version "${version}" \
-        '. += {"lastUpdate": $lastUpdate, "version": $version}')
-
-# Update the "get.jenkins.io" section of the existing report before returning it
-result=$(jq --argjson json "${json}" '."get.jenkins.io" |=  $json' "${reportName}")
-
-echo "${result}" > "${reportName}"
+echo "${json}"
+exit 0


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/4114, I got stuck because the shell is not portable and hard to test.

I also caught an issue with the partial update which could lead to data loss during generation of reports.

This PR aims at improving these 2 with the following changes:

- Ensure strict shellcheck on the current script
- Use a "./dist/" dir to store all reports (intermediate and final)
- Add a wrapper script to assemble the final JSON and treat version + date
- Change the pattern from "merge existing report + processes data" to "process data only and override existing script"
- Make code portable by getting rid of the non POSIX `readarray` instruction

----

How to test the scripts:

```bash
./generate-infra-data.sh index.json ./dist/ v2
```