### PR TITLE
chore: run reports only if their directory is changed or on principal branch

### DIFF
--- a/artifactory-users-report/Jenkinsfile
+++ b/artifactory-users-report/Jenkinsfile
@@ -1,5 +1,5 @@
 def cronExpr = env.BRANCH_IS_PRIMARY ? '@hourly' : ''
-def reportName = env.BRANCH_IS_PRIMARY ? 'artifactory-ldap-users-report.json' : "artifactory-ldap-users-report-${env.BRANCH_NAME}.json"
+def reportName = 'artifactory-ldap-users-report.json'
 
 pipeline {
   triggers {
@@ -8,14 +8,20 @@ pipeline {
   options {
     // This pipeline takes 1-2 minutes max to execute
     timeout(time: 10, unit: 'MINUTES')
-    lock(resource: 'infra-reports-artifactory-users', inversePrecedence: true)
+    lock(resource: "artifactory-ldap-users-report-${env.BRANCH_NAME}", inversePrecedence: true)
     buildDiscarder logRotator(daysToKeepStr: '90')
   }
   agent {
-     label 'jnlp-linux-arm64'
+    label 'jnlp-linux-arm64'
   }
   stages {
     stage('Generate Artifactory Users Report') {
+      when {
+        anyOf {
+          changeset 'artifactory-users-report/**/*'
+          expression { env.BRANCH_IS_PRIMARY }
+        }
+      }
       environment {
         ARTIFACTORY_AUTH = credentials('artifactoryAdmin')
         REPORT_NAME = "${reportName}"

--- a/fork-report/Jenkinsfile
+++ b/fork-report/Jenkinsfile
@@ -1,5 +1,5 @@
 def cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
-def reportName = env.BRANCH_IS_PRIMARY ? 'github-jenkinsci-fork-report.json' : "github-jenkinsci-fork-report-${env.BRANCH_NAME}.json"
+def reportName = 'github-jenkinsci-fork-report.json'
 
 pipeline {
   triggers {
@@ -8,7 +8,7 @@ pipeline {
   options {
     // This pipeline takes 1-2 minutes max to execute
     timeout(time: 10, unit: 'MINUTES')
-    lock(resource: 'infra-reports-github-forks', inversePrecedence: true)
+    lock(resource: "github-jenkinsci-fork-report-${env.BRANCH_NAME}", inversePrecedence: true)
     buildDiscarder logRotator(daysToKeepStr: '90')
   }
   agent {
@@ -16,6 +16,12 @@ pipeline {
   }
   stages {
     stage('Generate GitHub Forks Report') {
+      when {
+        anyOf {
+          changeset 'fork-report/**/*'
+          expression { env.BRANCH_IS_PRIMARY }
+        }
+      }
       environment {
         // Requires 'jenkins-infra-reports' to be of type GithubAppCredentials so $GITHUB_AUTH_PSW holds an IAT (Github Installation Access Token) valid for 1 hour
         GITHUB_AUTH = credentials('jenkins-infra-reports')

--- a/jenkins-infra-data/Jenkinsfile
+++ b/jenkins-infra-data/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
   options {
     // This pipeline takes 1-2 minutes max to execute
     timeout(time: 10, unit: 'MINUTES')
-    lock(resource: 'jenkins-infra-data', inversePrecedence: true)
+    lock(resource: "jenkins-infra-data-${env.BRANCH_NAME}", inversePrecedence: true)
     buildDiscarder logRotator(daysToKeepStr: '90')
   }
   agent {
@@ -26,7 +26,6 @@ pipeline {
   stages {
     stage('Generate Jenkins Infrastructure Public Data report') {
       when {
-        // Build only on principal branch, or if a change was found in the directory 'jenkins-infra-data/'
         anyOf {
           changeset 'jenkins-infra-data/**/*'
           expression { env.BRANCH_IS_PRIMARY }

--- a/jira-users-report/Jenkinsfile
+++ b/jira-users-report/Jenkinsfile
@@ -1,5 +1,5 @@
 def cronExpr = env.BRANCH_IS_PRIMARY ? 'H H/2 * * *' : ''
-def reportName = env.BRANCH_IS_PRIMARY ? 'jira-users-report.json' : "jira-users-report-${env.BRANCH_NAME}.json"
+def reportName = 'jira-users-report.json'
 
 pipeline {
   triggers {
@@ -8,7 +8,7 @@ pipeline {
   options {
     // This pipeline takes ~1.5 hour to run
     timeout(time: 2, unit: 'HOURS')
-    lock(resource: 'infra-reports-jira-users', inversePrecedence: true)
+    lock(resource: "jira-users-report-${env.BRANCH_NAME}", inversePrecedence: true)
     buildDiscarder logRotator(daysToKeepStr: '90')
   }
   agent {
@@ -16,6 +16,12 @@ pipeline {
   }
   stages {
     stage('Generate JIRA Users Report') {
+      when {
+        anyOf {
+          changeset 'jira-users-report/**/*'
+          expression { env.BRANCH_IS_PRIMARY }
+        }
+      }
       environment {
         JIRA_AUTH = credentials('jiraAuth')
         REPORT_NAME = "${reportName}"

--- a/maintainers-info-report/Jenkinsfile
+++ b/maintainers-info-report/Jenkinsfile
@@ -1,5 +1,5 @@
 def cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
-def reportName = env.BRANCH_IS_PRIMARY ? 'maintainers-info-report.json' : "maintainers-info-report-${env.BRANCH_NAME}.json"
+def reportName = 'maintainers-info-report.json'
 
 pipeline {
   triggers {
@@ -8,7 +8,7 @@ pipeline {
   options {
     // This pipeline takes 30-40 minutes to execute
     timeout(time: 1, unit: 'HOURS')
-    lock(resource: 'infra-reports-maintainers-info', inversePrecedence: true)
+    lock(resource: "maintainers-info-report-${env.BRANCH_NAME}", inversePrecedence: true)
     buildDiscarder logRotator(daysToKeepStr: '90')
   }
   agent {
@@ -16,6 +16,12 @@ pipeline {
   }
   stages {
     stage('Generate Maintainers Info Report') {
+      when {
+        anyOf {
+          changeset 'maintainers-info-report/**/*'
+          expression { env.BRANCH_IS_PRIMARY }
+        }
+      }
       environment {
         JIRA_AUTH = credentials('jiraAuth')
         REPORT_NAME = "${reportName}"

--- a/permissions-report/Jenkinsfile
+++ b/permissions-report/Jenkinsfile
@@ -1,5 +1,5 @@
 def cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
-def reportName = env.BRANCH_IS_PRIMARY ? 'github-jenkinsci-permissions-report.json' : "github-jenkinsci-permissions-report-${env.BRANCH_NAME}.json"
+def reportName = 'github-jenkinsci-permissions-report.json'
 
 pipeline {
   triggers {
@@ -8,7 +8,7 @@ pipeline {
   options {
     // This pipeline takes 6-7 hours max to execute
     timeout(time: 10, unit: 'HOURS')
-    lock(resource: 'infra-reports-github-permissions', inversePrecedence: true)
+    lock(resource: "github-jenkinsci-permissions-report-${env.BRANCH_NAME}", inversePrecedence: true)
     buildDiscarder logRotator(daysToKeepStr: '90')
   }
   agent {
@@ -16,12 +16,18 @@ pipeline {
   }
   stages {
     stage('Generate GitHub Permissions Report') {
-        environment {
-            GITHUB_APP_PRIVATE_KEY_B64 = credentials('githubapp-jenkins-infra-reports-private-key-b64')
-            GITHUB_APP_ID = credentials('githubapp-jenkins-infra-reports-app-identifier')
-            GITHUB_ORG_NAME = "jenkinsci"
-            REPORT_NAME = "${reportName}"
-          }
+      when {
+        anyOf {
+          changeset 'permissions-report/**/*'
+          expression { env.BRANCH_IS_PRIMARY }
+        }
+      }
+      environment {
+        GITHUB_APP_PRIVATE_KEY_B64 = credentials('githubapp-jenkins-infra-reports-private-key-b64')
+        GITHUB_APP_ID = credentials('githubapp-jenkins-infra-reports-app-identifier')
+        GITHUB_ORG_NAME = "jenkinsci"
+        REPORT_NAME = "${reportName}"
+      }
       steps {
         dir('permissions-report') {
           sh 'bundle install'

--- a/plugin-health-scoring/Jenkinsfile
+++ b/plugin-health-scoring/Jenkinsfile
@@ -1,6 +1,6 @@
 def cronExpr = env.BRANCH_IS_PRIMARY ? '@hourly' : ''
 def reportsFolder = 'plugin-health-scoring'
-def reportFile = env.BRANCH_IS_PRIMARY ? 'scores.json' : "scores-${env.BRANCH_NAME}.json"
+def reportFile = 'scores.json'
 def reportLines = 0
 
 pipeline {
@@ -16,7 +16,7 @@ pipeline {
 
   options {
     buildDiscarder logRotator(daysToKeepStr: '90')
-    lock(resource: 'plugin-health-scoring', inversePrecedence: true)
+    lock(resource: "plugin-health-scoring-${env.BRANCH_NAME}", inversePrecedence: true)
     timeout(time: 5, unit: 'MINUTES')
     disableConcurrentBuilds()
   }
@@ -26,6 +26,12 @@ pipeline {
   }
 
   stages {
+    when {
+      anyOf {
+        changeset 'plugin-health-scoring/**/*'
+        expression { env.BRANCH_IS_PRIMARY }
+      }
+    }
     stage('Generate Report') {
       steps {
         dir('plugin-health-scoring') {
@@ -36,6 +42,11 @@ pipeline {
     }
 
     stage('Publish if report not empty') {
+      when {
+        anyOf {
+          expression { env.BRANCH_IS_PRIMARY }
+        }
+      }
       steps {
         dir('plugin-health-scoring') {
           script {

--- a/plugin-health-scoring/Jenkinsfile
+++ b/plugin-health-scoring/Jenkinsfile
@@ -26,13 +26,13 @@ pipeline {
   }
 
   stages {
-    when {
-      anyOf {
-        changeset 'plugin-health-scoring/**/*'
-        expression { env.BRANCH_IS_PRIMARY }
-      }
-    }
     stage('Generate Report') {
+      when {
+        anyOf {
+          changeset 'plugin-health-scoring/**/*'
+          expression { env.BRANCH_IS_PRIMARY }
+        }
+      }
       steps {
         dir('plugin-health-scoring') {
           sh 'bash fetch-report.sh'

--- a/plugin-migration/Jenkinsfile
+++ b/plugin-migration/Jenkinsfile
@@ -1,5 +1,5 @@
 def cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
-def reportName = env.BRANCH_IS_PRIMARY ? 'jenkins-plugin-migration.html' : "jenkins-plugin-migration-${env.BRANCH_NAME}.html"
+def reportName = 'jenkins-plugin-migration.html'
 
 pipeline {
   triggers {
@@ -7,7 +7,7 @@ pipeline {
   }
   options {
     timeout(time: 10, unit: 'MINUTES')
-    lock(resource: 'infra-reports-plugin-migration', inversePrecedence: true)
+    lock(resource: "jenkins-plugin-migration-${env.BRANCH_NAME}", inversePrecedence: true)
     buildDiscarder logRotator(daysToKeepStr: '90')
   }
   agent {
@@ -15,13 +15,19 @@ pipeline {
   }
   stages {
     stage('Generate Plugin Documentation Migration Report') {
-        environment {
-            GITHUB_APP_PRIVATE_KEY_B64 = credentials('githubapp-jenkins-infra-reports-private-key-b64')
-            GITHUB_APP_ID = credentials('githubapp-jenkins-infra-reports-app-identifier')
-            GITHUB_ORG_NAME = "jenkinsci"
-            REPORT_NAME = "${reportName}"
-            NODE_ENV = "production"
-          }
+      when {
+        anyOf {
+          changeset 'plugin-migration/**/*'
+          expression { env.BRANCH_IS_PRIMARY }
+        }
+      }
+      environment {
+        GITHUB_APP_PRIVATE_KEY_B64 = credentials('githubapp-jenkins-infra-reports-private-key-b64')
+        GITHUB_APP_ID = credentials('githubapp-jenkins-infra-reports-app-identifier')
+        GITHUB_ORG_NAME = "jenkinsci"
+        REPORT_NAME = "${reportName}"
+        NODE_ENV = "production"
+      }
       steps {
         dir('plugin-migration') {
           sh 'npm ci'


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/4114, I was stuck on easily testing changes to reports in this repository.

This repository hosts a growing list of sub-projects, each one expected to generate a report and publish it to reports.jenkins.io: it is a "Monorepo" pattern and by experience it is hard to sustain growth on such pattern unless custom tooling is applied.

In order to make this growth sustainable, this PR introduces the following changes:

- To avoid long running PRs (and wasted resources), we want report generation to be executed only if their code is changed => added condition using the `changset` option on [`when`](https://www.jenkins.io/doc/book/pipeline/syntax/#built-in-conditions)
- Stop publishing PR reports on reports.jenkins.io => archive them instead as artifacts. They will be purged when build history will be cleaned up
- Avoid locking PR builds when the main branch is running since no PR reports are published
- A bit of pipeline syntax cleanup (mainly indentation)