### PR TITLE
fix(fork-report) add missing gems csv and logger

### DIFF
--- a/fork-report/Gemfile
+++ b/fork-report/Gemfile
@@ -7,3 +7,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 gem 'graphql-client'
 gem 'httparty'
 gem 'json'
+
+gem "csv", "~> 3.3"
+
+gem "logger", "~> 1.6"

--- a/fork-report/Gemfile.lock
+++ b/fork-report/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
     bigdecimal (3.1.7)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
+    csv (3.3.3)
     drb (2.2.1)
     fiber-storage (1.0.0)
     graphql (2.3.21)
@@ -29,6 +30,7 @@ GEM
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
+    logger (1.6.6)
     mini_mime (1.1.5)
     minitest (5.22.3)
     multi_xml (0.6.0)
@@ -40,9 +42,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  csv (~> 3.3)
   graphql-client
   httparty
   json
+  logger (~> 1.6)
 
 BUNDLED WITH
    2.5.7

--- a/fork-report/Gemfile.lock
+++ b/fork-report/Gemfile.lock
@@ -1,42 +1,50 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.2)
+    activesupport (8.0.2)
       base64
+      benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     base64 (0.2.0)
-    bigdecimal (3.1.7)
-    concurrent-ruby (1.2.3)
-    connection_pool (2.4.1)
+    benchmark (0.4.0)
+    bigdecimal (3.1.9)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
     csv (3.3.3)
     drb (2.2.1)
     fiber-storage (1.0.0)
-    graphql (2.3.21)
+    graphql (2.4.15)
       base64
       fiber-storage
-    graphql-client (0.21.0)
+      logger
+    graphql-client (0.25.0)
       activesupport (>= 3.0)
       graphql (>= 1.13.0)
-    httparty (0.21.0)
+    httparty (0.22.0)
+      csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.14.4)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    json (2.7.2)
+    json (2.10.2)
     logger (1.6.6)
     mini_mime (1.1.5)
-    minitest (5.22.3)
-    multi_xml (0.6.0)
-    mutex_m (0.2.0)
+    minitest (5.25.5)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
+    securerandom (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uri (1.0.3)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
This PR fixes missing gems (most probably removed from Ruby Core somewhere in 3.x): `csv` (hard error) and `logger` (warning before Ruby 3.5.0).

It also updates the sub-dependencies (ran a `bundle update`).