### PR TITLE
chore(github permission reports) increase pipeline timeout from 10 to 15 hours

### DIFF
--- a/permissions-report/Jenkinsfile
+++ b/permissions-report/Jenkinsfile
@@ -6,8 +6,8 @@ pipeline {
     cron(cronExpr)
   }
   options {
-    // This pipeline takes 6-7 hours max to execute
-    timeout(time: 10, unit: 'HOURS')
+    // This pipeline takes 9-10 hours max to execute
+    timeout(time: 15, unit: 'HOURS')
     lock(resource: "github-jenkinsci-permissions-report-${env.BRANCH_NAME}", inversePrecedence: true)
     buildDiscarder logRotator(daysToKeepStr: '90')
   }


### PR DESCRIPTION
Not sure why, but since the past ~ 35 days, the execution of this report is close to 10 hours while it use to be 6-7 hours.

We're using a GH app so https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/ does not apply 🤔 

Anyway: this minor change ensures the run goes to completion without being aborted at 10h mark.